### PR TITLE
[feat/no_mac_compatibility] Added logic for no mac command

### DIFF
--- a/packages/painperdu/src/components/PainPerdu/painPerdu.tsx
+++ b/packages/painperdu/src/components/PainPerdu/painPerdu.tsx
@@ -46,28 +46,29 @@ export const PainPerdu: FC<Props> = ({ pathItems, teleport }) => {
 	}
 
 	const commandsManager = (event: KeyboardEvent): void => {
-	   const commands: CommandHandler = {
-				KeyK: () => { openModal(event.metaKey) },
-  		  Escape: closeModal,
-		 }
-
-	   const { shouldCallFn } = useCommandManager(event.code, commands);
+		const isMac = navigator.userAgent.indexOf('Mac OS X') != -1
+		const eventKey = isMac ? event.metaKey : event.ctrlKey
+		const commands: CommandHandler = {
+			KeyK: () => { openModal(eventKey) },
+			Escape: closeModal,
+		}
+	  const { shouldCallFn } = useCommandManager(event.code, commands)
 
 		if (!shouldCallFn) {
 		  setEventToDispatch({
 				eventType: event.code
 			})
-			return;
-		};
+			return
+		}
 
 		if (commands) {
 		  if (commands[event.code]) {
-				  if (typeof commands[event.code] === 'function') {
-				      commands[event.code]?.call(null);
-						}
+				if (typeof commands[event.code] === 'function') {
+				  commands[event.code]?.call(null)
 				}
+			}
 		}
-	};
+	}
 
 	useEffect(() => {
 		window.addEventListener('keydown', commandsManager)

--- a/packages/painperdu/src/components/PainPerdu/painPerdu.tsx
+++ b/packages/painperdu/src/components/PainPerdu/painPerdu.tsx
@@ -46,7 +46,7 @@ export const PainPerdu: FC<Props> = ({ pathItems, teleport }) => {
 	}
 
 	const commandsManager = (event: KeyboardEvent): void => {
-		const isMac = navigator.userAgent.indexOf('Mac OS X') != -1
+ 		const eventKey = navigator.userAgent.replace(/\s/g, "").toUppercase().includes('MACOSX') ? event.metaKey : event.ctrlKey
 		const eventKey = isMac ? event.metaKey : event.ctrlKey
 		const commands: CommandHandler = {
 			KeyK: () => { openModal(eventKey) },

--- a/packages/painperdu/src/components/PainPerdu/painPerdu.tsx
+++ b/packages/painperdu/src/components/PainPerdu/painPerdu.tsx
@@ -46,8 +46,7 @@ export const PainPerdu: FC<Props> = ({ pathItems, teleport }) => {
 	}
 
 	const commandsManager = (event: KeyboardEvent): void => {
- 		const eventKey = navigator.userAgent.replace(/\s/g, "").toUppercase().includes('MACOSX') ? event.metaKey : event.ctrlKey
-		const eventKey = isMac ? event.metaKey : event.ctrlKey
+ 		const eventKey = navigator.userAgent.replace(/\s/g, "").toUpperCase().includes('MACOSX') ? event.metaKey : event.ctrlKey
 		const commands: CommandHandler = {
 			KeyK: () => { openModal(eventKey) },
 			Escape: closeModal,


### PR DESCRIPTION
## No Mac compatibility

Actually to trigger the modal we detect if user click on CMD + K keyboard but if user is not on **Mac Os** the keyboard combinaison will not working.

## Ticket : 

- https://www.notion.so/e4700f93fdc247dcae38bce6bff88322?v=5b559d76a27a4d7f8bee138f79c83648&p=f7cd6b0d40764636b30e3c633f94fcb8&pm=s